### PR TITLE
Category Service and the eventsId retruning

### DIFF
--- a/categoryplace-service/pom.xml
+++ b/categoryplace-service/pom.xml
@@ -93,6 +93,18 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+		    <groupId>io.projectreactor</groupId>
+		    <artifactId>reactor-test</artifactId>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.mockito</groupId>
+		    <artifactId>mockito-core</artifactId>
+		    <scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>com.mycity.shared</groupId>
 			<artifactId>mycity-common-dtos</artifactId>

--- a/categoryplace-service/src/main/java/com/mycity/category/controller/CategoryController.java
+++ b/categoryplace-service/src/main/java/com/mycity/category/controller/CategoryController.java
@@ -23,8 +23,11 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/category")
 public class CategoryController {
 
-    @Autowired
-    private CategoryService categoryService;
+	private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
 
     @GetMapping("/unique/images")
     public Mono<ResponseEntity<List<CategoryImageDTO>>> getCategoriesWithImages() {

--- a/categoryplace-service/src/test/java/com/mycity/category/CategoryplaceServiceApplicationTests.java
+++ b/categoryplace-service/src/test/java/com/mycity/category/CategoryplaceServiceApplicationTests.java
@@ -1,4 +1,4 @@
-package com.mycity.categoryplace_service;
+package com.mycity.category;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/categoryplace-service/src/test/java/com/mycity/category/test/CategoryControllerTest.java
+++ b/categoryplace-service/src/test/java/com/mycity/category/test/CategoryControllerTest.java
@@ -1,0 +1,110 @@
+package com.mycity.category.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import com.mycity.category.controller.CategoryController;
+import com.mycity.category.service.CategoryService;
+import com.mycity.shared.categorydto.CategoryDTO;
+import com.mycity.shared.categorydto.CategoryImageDTO;
+
+import reactor.core.publisher.Mono;
+
+public class CategoryControllerTest {
+
+    @Mock
+    private CategoryService categoryService;
+
+    private CategoryController categoryController;
+
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        categoryController = new CategoryController(categoryService); // pass mock via constructor
+        webTestClient = WebTestClient.bindToController(categoryController).build();
+    }
+
+
+    @Test
+    public void testGetCategoriesWithImages() {
+        List<CategoryImageDTO> mockList = Arrays.asList(
+            new CategoryImageDTO("Art", "http://example.com/image1.jpg"),
+            new CategoryImageDTO("Music", "http://example.com/image2.jpg")
+        );
+
+        when(categoryService.fetchCategoriesWithImages()).thenReturn(Mono.just(mockList));
+
+        webTestClient.get()
+                .uri("/category/unique/images")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(CategoryImageDTO.class)
+                .hasSize(2)
+                .contains(mockList.get(0), mockList.get(1));
+    }
+
+    @Test
+    public void testCategoryExists() {
+        when(categoryService.categoryExists("Art")).thenReturn(true);
+
+        ResponseEntity<Boolean> response = categoryController.categoryExists("Art");
+
+        assertEquals(Boolean.TRUE, response.getBody());
+    }
+
+    @Test
+    public void testCreateCategory() {
+        CategoryDTO input = new CategoryDTO("Art", "Artistic category");
+
+        when(categoryService.createCategory("Art", "Artistic category")).thenReturn(input);
+
+        ResponseEntity<CategoryDTO> response = categoryController.createCategory(input);
+
+        assertEquals(201, response.getStatusCodeValue());
+        assertEquals("Art", response.getBody().getName());
+    }
+
+    @Test
+    public void testGetCategoryByName() {
+        CategoryDTO mockDTO = new CategoryDTO("Music", "Musical vibes");
+
+        when(categoryService.getCategoryByName("Music")).thenReturn(mockDTO);
+
+        ResponseEntity<CategoryDTO> response = categoryController.getCategoryByName("Music");
+
+        assertEquals("Musical vibes", response.getBody().getDescription());
+    }
+
+    @Test
+    public void testSaveCategory() {
+        CategoryDTO dto = new CategoryDTO("Travel", "Travel category");
+
+        when(categoryService.saveCategory(dto)).thenReturn(dto);
+
+        ResponseEntity<CategoryDTO> response = categoryController.saveCategory(dto);
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals("Travel", response.getBody().getName());
+    }
+
+    @Test
+    public void testGetCategoryDescriptionByName() {
+        when(categoryService.getDescriptionByCategoryName("Tech")).thenReturn("Technology related");
+
+        ResponseEntity<String> response = categoryController.getCategoryDescriptionByName("Tech");
+
+        assertEquals("Technology related", response.getBody());
+    }
+}

--- a/categoryplace-service/src/test/java/com/mycity/category/test/CategoryRepositoryTest.java
+++ b/categoryplace-service/src/test/java/com/mycity/category/test/CategoryRepositoryTest.java
@@ -1,0 +1,96 @@
+package com.mycity.category.test;
+
+import com.mycity.category.entity.Category;
+import com.mycity.category.repository.CategoryRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class CategoryRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private Category category1;
+    private Category category2;
+    private Category category3;
+
+    @BeforeEach
+    public void setUp() {
+        category1 = new Category();
+        category1.setName("Parks");
+        category1.setDescription("Public recreational spaces for relaxation.");
+
+        category2 = new Category();
+        category2.setName("Monuments");
+        category2.setDescription("Historical sites and statues.");
+
+        category3 = new Category();
+        category3.setName("Museums");
+        category3.setDescription("Institutions that preserve and exhibit art or science.");
+
+        categoryRepository.save(category1);
+        categoryRepository.save(category2);
+        categoryRepository.save(category3);
+    }
+    
+    @Test
+    public void testFindByName() {
+        Category result = categoryRepository.findByName("Parks");
+        assertNotNull(result);
+        assertEquals("Parks", result.getName());
+        assertEquals("Public recreational spaces for relaxation.", result.getDescription());
+    }
+
+    @Test
+    public void testExistsByNameIgnoreCase() {
+        boolean exists = categoryRepository.existsByNameIgnoreCase("parks");
+        assertTrue(exists);
+    }
+
+    @Test
+    public void testFindByNameIgnoreCase() {
+        Optional<Category> result = categoryRepository.findByNameIgnoreCase("MONUMENTS");
+        assertTrue(result.isPresent());
+        assertEquals("Monuments", result.get().getName());
+    }
+
+    @Test
+    public void testFindDescriptionsByNameIgnoreCase() {
+        List<String> descriptions = categoryRepository.findDescriptionsByNameIgnoreCase("parks");
+        assertEquals(1, descriptions.size());
+        assertEquals("Public recreational spaces for relaxation.", descriptions.get(0));
+    }
+
+    @Test
+    public void testFindAllByName() {
+        List<Category> categories = categoryRepository.findAllByName("Parks");
+        assertEquals(1, categories.size());
+        assertEquals("Parks", categories.get(0).getName());
+    }
+
+    @Test
+    public void testSaveCategory() {
+        Category newCategory = new Category();
+        newCategory.setName("Beaches");
+        newCategory.setDescription("Coastal areas for swimming and sunbathing.");
+
+        Category savedCategory = categoryRepository.save(newCategory);
+
+        assertNotNull(savedCategory);
+        assertEquals("Beaches", savedCategory.getName());
+        assertEquals("Coastal areas for swimming and sunbathing.", savedCategory.getDescription());
+    }
+}

--- a/categoryplace-service/src/test/java/com/mycity/category/test/CategoryServiceImplTest.java
+++ b/categoryplace-service/src/test/java/com/mycity/category/test/CategoryServiceImplTest.java
@@ -1,0 +1,153 @@
+package com.mycity.category.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.mycity.category.entity.Category;
+import com.mycity.category.repository.CategoryRepository;
+import com.mycity.category.serviceImpl.CategoryServiceImpl;
+import com.mycity.category.serviceImpl.WebClientMediaService;
+import com.mycity.category.serviceImpl.WebClientPlaceService;
+import com.mycity.shared.categorydto.CategoryDTO;
+import com.mycity.shared.categorydto.CategoryImageDTO;
+import com.mycity.shared.placedto.PlaceCategoryDTO;
+
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@SpringBootTest
+public class CategoryServiceImplTest {
+
+    @InjectMocks
+    private CategoryServiceImpl categoryService;
+
+    @Mock
+    private CategoryRepository categoryRepo;
+
+    @Mock
+    private WebClientPlaceService placeService;
+
+    @Mock
+    private WebClientMediaService mediaService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testCategoryExists_ReturnsTrue() {
+        when(categoryRepo.existsByNameIgnoreCase("Historic")).thenReturn(true);
+        boolean exists = categoryService.categoryExists("Historic");
+        assertTrue(exists);
+    }
+
+    @Test
+    public void testGetCategoryByName_ReturnsCategoryDTO() {
+        Category category = new Category();
+        category.setCategoryId(1L);
+        category.setName("Temples");
+        category.setDescription("Spiritual locations");
+
+        when(categoryRepo.findByNameIgnoreCase("Temples")).thenReturn(Optional.of(category));
+
+        CategoryDTO dto = categoryService.getCategoryByName("Temples");
+
+        assertNotNull(dto);
+        assertEquals("Temples", dto.getName());
+        assertEquals("Spiritual locations", dto.getDescription());
+    }
+
+    @Test
+    public void testCreateCategory_Success() {
+        Category toSave = new Category();
+        toSave.setName("Nature");
+        toSave.setDescription("Natural sights");
+
+        Category saved = new Category();
+        saved.setCategoryId(2L);
+        saved.setName("Nature");
+        saved.setDescription("Natural sights");
+
+        when(categoryRepo.existsByNameIgnoreCase("Nature")).thenReturn(false);
+        when(categoryRepo.save(any(Category.class))).thenReturn(saved);
+
+        CategoryDTO result = categoryService.createCategory("Nature", "Natural sights");
+
+        assertNotNull(result);
+        assertEquals("Nature", result.getName());
+        assertEquals("Natural sights", result.getDescription());
+    }
+
+    @Test
+    public void testSaveCategory_Success() {
+        CategoryDTO dto = new CategoryDTO();
+        dto.setName("Adventure");
+        dto.setDescription("Thrilling experiences");
+        dto.setPlaceId(1L);
+        dto.setPlaceName("Mountain Climb");
+
+        Category saved = new Category();
+        saved.setCategoryId(3L);
+        saved.setName("Adventure");
+        saved.setDescription("Thrilling experiences");
+        saved.setPlaceId(1L);
+        saved.setPlaceName("Mountain Climb");
+
+        when(categoryRepo.save(any(Category.class))).thenReturn(saved);
+
+        CategoryDTO result = categoryService.saveCategory(dto);
+
+        assertNotNull(result);
+        assertEquals("Adventure", result.getName());
+        assertEquals("Thrilling experiences", result.getDescription());
+    }
+
+    @Test
+    public void testFetchCategoryDescription_ReturnsDescription() {
+        when(categoryRepo.findDescriptionsByNameIgnoreCase("Cultural")).thenReturn(List.of("Cultural heritage"));
+
+        String description = categoryService.fetchCategoryDescription("Cultural").block();
+
+        assertEquals("Cultural heritage", description);
+    }
+
+    @Test
+    public void testFetchCategoriesWithImages_ReturnsUniqueCategoryImageDTOs() {
+        // Duplicate category "Cultural", only one should be included
+        PlaceCategoryDTO place1 = new PlaceCategoryDTO("Cultural", 101L, "Heritage Museum");
+        PlaceCategoryDTO place2 = new PlaceCategoryDTO("Cultural", 102L, "Folk Center");
+        PlaceCategoryDTO place3 = new PlaceCategoryDTO("Nature", 103L, "National Park");
+
+        when(placeService.fetchPlaceCategories()).thenReturn(Flux.just(place1, place2, place3));
+        when(mediaService.fetchCategoryImage("Cultural")).thenReturn(Mono.just("img-cultural"));
+        when(mediaService.fetchCategoryImage("Nature")).thenReturn(Mono.just("img-nature"));
+
+        when(categoryRepo.findDescriptionsByNameIgnoreCase("Cultural")).thenReturn(List.of("Heritage sites"));
+        when(categoryRepo.findDescriptionsByNameIgnoreCase("Nature")).thenReturn(List.of("Nature exploration"));
+
+        List<CategoryImageDTO> result = categoryService.fetchCategoriesWithImages().block();
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        CategoryImageDTO cultural = result.stream().filter(dto -> dto.getCategoryName().equals("Cultural")).findFirst().orElse(null);
+        CategoryImageDTO nature = result.stream().filter(dto -> dto.getCategoryName().equals("Nature")).findFirst().orElse(null);
+
+        assertNotNull(cultural);
+        assertEquals("img-cultural", cultural.getImageUrl());
+        assertEquals("Heritage sites", cultural.getPlaceDescription());
+
+        assertNotNull(nature);
+        assertEquals("img-nature", nature.getImageUrl());
+        assertEquals("Nature exploration", nature.getPlaceDescription());
+    }
+}

--- a/categoryplace-service/src/test/resources/application-test.properties
+++ b/categoryplace-service/src/test/resources/application-test.properties
@@ -1,13 +1,8 @@
-spring.application.name=category-service
-
-server.port=8089
-
-
 #Database Properties
 
 spring.datasource.url=jdbc:mysql://localhost:3306/categorydb
 
-spring.datasource.username=rootss
+spring.datasource.username=root
 
 spring.datasource.password=root
 

--- a/client-service/src/main/java/com/mycity/client/config/SecurityConfig.java
+++ b/client-service/src/main/java/com/mycity/client/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3001")); // ✅ Replace with real ngrok origin
+        config.setAllowedOrigins(List.of("http://localhost:3000")); // ✅ Replace with real ngrok origin
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/eventsplace-service/src/main/java/com/mycity/eventsplace/serviceImpl/EventsPlaceService.java
+++ b/eventsplace-service/src/main/java/com/mycity/eventsplace/serviceImpl/EventsPlaceService.java
@@ -236,6 +236,7 @@ public class EventsPlaceService implements EventsPlaceServiceInterface {
            data.put("date", eventsList.getDate());
          // Directly a list of strings
            data.put("city", eventsList.getCity());
+           data.put("eventId",eventsList.getEventId());
           
     // assuming Event has getPlace()
            try {

--- a/media-service/src/main/java/com/mycity/media/config/MediaSecurityConfig.java
+++ b/media-service/src/main/java/com/mycity/media/config/MediaSecurityConfig.java
@@ -20,7 +20,7 @@ public class MediaSecurityConfig {
 	        .csrf(csrf -> csrf.disable())
 	        .authorizeHttpRequests(auth -> auth
 	            .requestMatchers("/media/upload/image","/media/images/**","/media/upload","/media/cover-image","/media/fetch{id}","/media/images/{placeId}","/media/images/delete/{placeId}",
-	            		         "/media/review/upload","/media/review/delete/{reviewId}",
+	            		         "/media/review/upload","/media/review/delete/{reviewId}","media/bycategory/image",
 	            		         "/media/gallery/upload","media/gallery/getimages/{districtName}","/media/gallery/deleteimage/{imageId}","/media/image-byplacename/{placeName}","/media/upload/places","/media/upload/cuisines","/media/upload/images", "/media/delete/images/**", "/media/update/images/**", "/media/fetch/images/**")
 	            .permitAll()
 	            .anyRequest().authenticated()
@@ -46,4 +46,5 @@ public class MediaSecurityConfig {
 	    public WebClient.Builder webClientBuilder() {
 	        return WebClient.builder();    
 	    }
+	    
 }

--- a/mycity-common-dtos/src/main/java/com/mycity/shared/categorydto/CategoryDTO.java
+++ b/mycity-common-dtos/src/main/java/com/mycity/shared/categorydto/CategoryDTO.java
@@ -9,9 +9,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CategoryDTO {
 
-	 	public CategoryDTO(String categoryName, String categoryDescription) {
-		// TODO Auto-generated constructor stub
-	}
+	 public CategoryDTO(String name, String description) {
+	        this.name = name;
+	        this.description = description;
+	    }
 
 		private Long categoryId;
 

--- a/mycity-common-dtos/src/main/java/com/mycity/shared/categorydto/CategoryImageDTO.java
+++ b/mycity-common-dtos/src/main/java/com/mycity/shared/categorydto/CategoryImageDTO.java
@@ -9,6 +9,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CategoryImageDTO { 
 	
+	public CategoryImageDTO(String categoryname, String image) {
+		// TODO Auto-generated constructor stub
+	}
 	private String categoryName;
     private String imageUrl;
     private String placeId;

--- a/mycity-common-dtos/src/main/java/com/mycity/shared/placedto/PlaceCategoryDTO.java
+++ b/mycity-common-dtos/src/main/java/com/mycity/shared/placedto/PlaceCategoryDTO.java
@@ -19,4 +19,11 @@ public class PlaceCategoryDTO {
         this.categoryId = categoryId;
     }
 
+	public PlaceCategoryDTO(String categoryName, long placeId, String placeName) {
+		// TODO Auto-generated constructor stub
+		this.categoryName=categoryName;
+		this.placeId=placeId;
+		this.placeName=placeName;
+	}
+
 }

--- a/place-service/src/main/java/com/mycity/place/config/SecurityConfig.java
+++ b/place-service/src/main/java/com/mycity/place/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig
                     "/place/get/{placeId}",
                     "/place/update/{placeId}",
                     "place/places/categories",
-                    "place/about/{placeId}"
+                    "place/about/{placeId}",
+                    "place/placeby/categories"
                     
                 ).permitAll()
                 .anyRequest().authenticated()


### PR DESCRIPTION
Added **JUnit** tests for Category Service:

Controller tests using **@WebMvcTest**

Service layer tests

Repository tests using **@DataJpaTest** with the main application database (not using an in-memory test database)

Updated security configurations in Media Service and Category Service to allow access to required endpoints

Modified EventPlace response to include eventId along with placeId